### PR TITLE
Bump build target to DotNet 6.0

### DIFF
--- a/xeokit/test/test.csproj
+++ b/xeokit/test/test.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/xeokit/xeokit-metadata/xeokit-metadata.csproj
+++ b/xeokit/xeokit-metadata/xeokit-metadata.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <PackageVersion>1.0.0</PackageVersion>
         <Title>xeokit-metadata</Title>


### PR DESCRIPTION
There are couple of reasons why we want to update to DotNet 6:

- The support of DotNet 3.1 will stop in December 2022.
- Major Linux distros like don't support DotNet 3.1 anymore, i.e. Ubuntu 22.04 (At OpenProject we want to support that Ubuntu version for our OpenProject BIM edition (https://community.openproject.org/projects/openproject/work_packages/43531))
